### PR TITLE
Add outputBase option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,10 @@ const stencil = require('@stencil/webpack');
 
 ```
 
+### Options
+
+- **outputBase**: Base directory to copy component assets into (eg `"static/js"`)
+
 ## Related
 
 * [Stencil](https://stenciljs.com/)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,11 @@ import * as path from 'path';
 
 class StencilPlugin {
   private fs: FS;
+  private outputBase: string;
+
+  constructor(options: PluginOptions = {}) {
+    this.outputBase = options.outputBase || ""
+  }
 
   apply(compiler: any) {
     compiler.plugin('emit', (compilation: Complication, callback: Function) => {
@@ -67,7 +72,7 @@ class StencilPlugin {
 
     const data = await this.readFile(filePath);
 
-    const assetPath = normalizePath(path.join(appNamespace, path.relative(appAssetsDir, filePath)));
+    const assetPath = normalizePath(path.join(this.outputBase, appNamespace, path.relative(appAssetsDir, filePath)));
 
     assets[assetPath] = {
       source: () => data,
@@ -166,4 +171,8 @@ interface FsStats {
   isFile(): boolean;
   isDirectory(): boolean;
   size: number;
+}
+
+interface PluginOptions {
+  outputBase?: string
 }


### PR DESCRIPTION
#### Short description of what this resolves:

There doesn't seem to be any way to control where the Stencil components wind up after Webpack runs. In my case, the server I'm using expects assets to be in a "static/js" folder, so my components don't load if they're just placed in the base output directory.

#### Changes proposed in this pull request:

Adds an `outputBase` option to the plugin class, which controls the base directory that component assets are copied into.

I'm not quite sure what would be involved in adding a test for the new option, since it seems like the `MockCompiler` would have to be built out some, but I'd be happy to try and put one together!