### PR TITLE
Updating plugin to use proper webpack 4 apis

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,44 @@
+@Library(['pureconnect-builds', 'devops-buildtools']) _
+
+Map config = [ emails: 'PureConnectWebAppsArchitects@genesys.com' ];
+pipeline {
+    agent {
+        label 'linux && node10'
+    }
+
+    stages {
+        stage('Bootstrap') {
+            steps {
+                sh 'npm ci'
+            }
+        }
+        stage('Build') {
+            steps {
+                sh 'npm run build'
+            }
+        }
+        stage('Test') {
+            steps {
+                sh 'npm run test'
+            }
+        }
+        stage('Publish') {
+            steps {
+                echo 'Publish to artifactory'
+                publishNpmPackage()
+            }
+        }
+    }
+    post {
+        success { 
+            script {
+                postBuild.success(config)
+            }
+        }
+        failure {
+            script {
+                postBuild.failure(config)
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stencil/webpack",
+  "name": "@pureconnect/stencil-webpack",
   "version": "0.0.6",
   "license": "MIT",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ionic-team/stencil-webpack.git"
+    "url": "git+https://github.com/GenesysPureConnect/stencil-webpack.git"
   },
   "author": "Ionic Team",
   "homepage": "https://stenciljs.com/",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,8 @@ class StencilPlugin {
   private fs: FS;
 
   apply(compiler: any) {
-    compiler.plugin('emit', (compilation: Complication, callback: Function) => {
+    compiler.hooks.emit.tapAsync('StencilPlugin',
+    (compilation: Complication, callback: Function) => {
       this.fs = compiler.inputFileSystem;
       this.inspectModules(compilation.assets, compilation.modules).then(() => {
         callback();

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -40,10 +40,8 @@ describe('plugin', () => {
     const plugin = new Plugin({
       collections: 'node_modules/tool-components/toolcomponents'
     });
-    sinon.spy(mockCompiler, 'plugin');
+    var callback = sinon.spy(mockCompiler.hooks.emit, 'tapAsync');
     plugin.apply(mockCompiler);
-    expect(mockCompiler.plugin.calledOnce).to.be.true;
-    expect(mockCompiler.plugin.calledWith('emit')).to.be.true;
+    expect(callback.called).to.true
   });
-
 });

--- a/test/mock-compiler.js
+++ b/test/mock-compiler.js
@@ -1,3 +1,9 @@
-module.exports = class {
-  plugin() {}
+module.exports = function() {
+  return {
+    hooks: {
+      emit: {
+        tapAsync: () => {}
+      }
+    }
+  }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Uses webpack 4 tappable APIs from the compiler

**Fixes**: #5
