### PR TITLE
fix: update plugin to work with Webpack 5

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
 import * as path from 'path';
 
-
 class StencilPlugin {
   private fs: FS;
 
   apply(compiler: any) {
-    compiler.plugin('emit', (compilation: Complication, callback: Function) => {
+    compiler.hooks.emit.tapAsync('StencilPlugin', (compilation: Complication, callback: Function) => {
       this.fs = compiler.inputFileSystem;
       this.inspectModules(compilation.assets, compilation.modules).then(() => {
         callback();

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -40,10 +40,10 @@ describe('plugin', () => {
     const plugin = new Plugin({
       collections: 'node_modules/tool-components/toolcomponents'
     });
-    sinon.spy(mockCompiler, 'plugin');
+    sinon.spy(mockCompiler.hooks.emit, 'tapAsync');
     plugin.apply(mockCompiler);
-    expect(mockCompiler.plugin.calledOnce).to.be.true;
-    expect(mockCompiler.plugin.calledWith('emit')).to.be.true;
+    expect(mockCompiler.hooks.emit.tapAsync.calledOnce).to.be.true;
+    expect(mockCompiler.hooks.emit.tapAsync.calledWith('StencilPlugin')).to.be.true;
   });
 
 });

--- a/test/mock-compiler.js
+++ b/test/mock-compiler.js
@@ -1,3 +1,7 @@
 module.exports = class {
-  plugin() {}
+  hooks = {
+    emit: {
+      tapAsync(){}
+    }
+  }
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Updates the plugin to work with Webpack 5.

#### Changes proposed in this pull request:

Changes plugin to use compiler hooks API.

**Fixes**: #8 
